### PR TITLE
Add Go and Python concurrency benchmark setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ docker-compose up --build bench
 ```
 
 The benchmark runs for 5 minutes against each server and saves a Markdown report inside `results/report.md`.
+An example report is already included in that directory. Run the command above to generate real numbers on your machine.
 
 ## Services
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Go vs Python Concurrency Benchmark
+
+This setup compares a simple HTTP server written in Go with one written in Python using FastAPI. The benchmark uses **wrk** for load testing and can be run with Docker Compose.
+
+## Usage
+
+```bash
+docker-compose up --build bench
+```
+
+The benchmark runs for 5 minutes against each server and saves a Markdown report inside `results/report.md`.
+
+## Services
+
+- **go** – compiled static binary based on `scratch`.
+- **python** – FastAPI running on `uvicorn`.
+- **bench** – Alpine container running `wrk` to generate load.
+
+Ports 8081 and 8082 expose the Go and Python servers respectively.

--- a/bench/Dockerfile
+++ b/bench/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine
+RUN apk add --no-cache wrk
+COPY benchmark.sh /benchmark.sh
+CMD ["/benchmark.sh"]

--- a/bench/benchmark.sh
+++ b/bench/benchmark.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+sleep 5
+mkdir -p /results
+
+printf "## Go Benchmark\n" > /results/report.md
+wrk -t4 -c100 -d5m http://go:8080 >> /results/report.md
+
+printf "\n## Python Benchmark\n" >> /results/report.md
+wrk -t4 -c100 -d5m http://python:8080 >> /results/report.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+services:
+  go:
+    build: ./go
+    ports:
+      - "8081:8080"
+  python:
+    build: ./python
+    ports:
+      - "8082:8080"
+  bench:
+    build: ./bench
+    depends_on:
+      - go
+      - python
+    volumes:
+      - ./results:/results
+    command: ["/benchmark.sh"]

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.22 AS builder
+WORKDIR /src
+COPY go.mod ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o server server.go
+
+FROM scratch
+COPY --from=builder /src/server /server
+EXPOSE 8080
+ENTRYPOINT ["/server"]

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module benchmark/go
+
+go 1.22

--- a/go/server.go
+++ b/go/server.go
@@ -6,8 +6,12 @@ import (
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	time.Sleep(time.Millisecond)
-	w.Write([]byte("ok"))
+	ch := make(chan string)
+	go func() {
+		time.Sleep(time.Millisecond)
+		ch <- "ok"
+	}()
+	w.Write([]byte(<-ch))
 }
 
 func main() {

--- a/go/server.go
+++ b/go/server.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"net/http"
+	"time"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	time.Sleep(time.Millisecond)
+	w.Write([]byte("ok"))
+}
+
+func main() {
+	http.HandleFunc("/", handler)
+	http.ListenAndServe(":8080", nil)
+}

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY server.py ./
+EXPOSE 8080
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/python/server.py
+++ b/python/server.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+import asyncio
+
+app = FastAPI()
+
+@app.get('/')
+async def read_root():
+    await asyncio.sleep(0.001)
+    return {"message": "ok"}
+
+if __name__ == '__main__':
+    import uvicorn
+    uvicorn.run(app, host='0.0.0.0', port=8080)

--- a/results/report.md
+++ b/results/report.md
@@ -1,0 +1,21 @@
+## Go Benchmark (example)
+```
+Running 5m test @ http://go:8080
+  4 threads and 100 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     1.2ms    0.8ms    15ms   75.00%
+    Req/Sec    65k      4k      80k     60.00%
+  19,500,000 requests in 5.00m, 1.3GB read
+```
+
+## Python Benchmark (example)
+```
+Running 5m test @ http://python:8080
+  4 threads and 100 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     5.1ms    2.0ms    30ms   70.00%
+    Req/Sec    19k      2k      24k     65.00%
+  5,700,000 requests in 5.00m, 430MB read
+```
+
+These numbers are illustrative. Run `docker-compose up --build bench` to produce real results.


### PR DESCRIPTION
## Summary
- add Go HTTP server with minimal scratch image
- add Python FastAPI server
- set up wrk benchmarking container
- orchestrate with docker-compose
- document usage instructions

## Testing
- `go vet ./...`
- `python3 -m py_compile python/server.py`
- `go build`

------
https://chatgpt.com/codex/tasks/task_e_6855d6152eb0832db3031b61dfc6fded